### PR TITLE
feat: Enable page-by-page scrolling with mouse wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ A Greasy Fork user script for exhentai
     * ![5](https://raw.githubusercontent.com/Sean2525/Let-s-panda/master/images/5.png)
 * When you are in double mode, click the double mode button once more and it will reverse image like this.
     * ![6](https://raw.githubusercontent.com/Sean2525/Let-s-panda/master/images/6.png)
+#### Keyboard Shortcuts
+* You can use the `Up (↑)` and `Down (↓)` arrow keys or the `W`, `A` and `Space` keys to switch images.
+* In `Viewer page(s): One` mode, you can use the `Left (←)` and `Right (→)` arrow keys or the `A` and `D` keys to turn pages.
 
 ### Install the Script
 

--- a/src/main.js
+++ b/src/main.js
@@ -1071,6 +1071,10 @@ text-decoration: none;
         document.addEventListener("keydown", (e) => {
           let nextImg = null;
 
+          // Check if the current focus is on an input or textarea element
+          if (document.activeElement.tagName === "INPUT" || document.activeElement.tagName === "TEXTAREA") {
+            return;
+          }
 
           // ignore key combinations
           if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
**I took the lazy way out and had AI write the following for me : )**

This PR introduces a significant user experience enhancement to the image viewer by enabling page-by-page navigation using the mouse wheel in "full image mode."

This provides a more intuitive and efficient way to browse galleries, aligning the wheel's behavior with the existing keyboard (ArrowUp/ArrowDown) navigation.

**Key Changes ✨**
- **Wheel-based Page Navigation**: Users can now scroll up or down with the mouse wheel to instantly navigate to the previous or next image when "full image mode" is active. In other modes, the wheel retains its default smooth scrolling behavior.
- **Refactored Navigation Logic**: The logic for finding the next target image has been extracted into a reusable `findNextImg` function. Both keyboard and wheel navigation now use this function, improving code maintainability and consistency.
- **Event Handling Fix**: Correctly implemented ` passive: false }` in the `wheel` event listener to ensure `e.preventDefault()` can be called successfully, resolving browser warnings related to passive event listeners.

**Implementation Details 🛠️**
1. A new `wheel` event listener is added to the `document`.
2. It first checks if "full image mode" (`full_image`) is enabled. If not, it exits to preserve default scrolling.
3. In full image mode, it determines the scroll direction (up or down).
4. It calls the `findNextImg` function, which uses `getBoundingClientRect` to locate the appropriate target image based on its position relative to the viewport.
5. If a target image is found, it prevents the browser's default scroll action and instantly scrolls the view to the top of that image (`offsetTop`).