### PR TITLE
feat: Improve full image mode to prevent overflow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1250,11 +1250,11 @@ text-decoration: none;
     if (full_image == true) {
       $("#gdt")
         .find("img")
-        .css({ "height": "100vh", "width": "auto" });
+        .css({ "height": "100vh", "width": "auto", "max-width": "100%", "object-fit": "contain" });
     } else {
       $("#gdt")
         .find("img")
-        .css({ "height": "auto", "width": $(window).width() * width });
+        .css({ "height": "", "width": $(window).width() * width, "max-width": "", "object-fit": "" });
     }
   }
 


### PR DESCRIPTION
**I was lazy again and had AI write the following for me :)**

This pull request enhances the user experience in "full image" mode.

Previously, when an image's original width exceeded the window's width, it would overflow the screen, causing a horizontal scrollbar to appear. This update ensures that images are always fully visible within the viewport.

**Changes:**

- Added `max-width: 100%` and `object-fit: contain` to the CSS for images in full image mode.
- This constrains the image width to the window size while maintaining its original aspect ratio.
- Ensured that these styles are correctly removed when switching out of full image mode.

**Effect comparison (Before & After):**

**Before**: (Image overflows the screen, requiring horizontal scrolling)

![『BanG Dream! Girls Band Party!』MyGO!!!!!×Ave Mujica Contract LIVE commemorative event card - ExHentai org - Google Chrome 2025_10_1 2_20_29](https://github.com/user-attachments/assets/f68fecc9-c9ad-4a61-8e2c-7ce82f39d551)

**After**: (Image is scaled down to fit the window width, remaining fully visible)

![『BanG Dream! Girls Band Party!』MyGO!!!!!×Ave Mujica Contract LIVE commemorative event card - ExHentai org - Google Chrome 2025_10_1 2_20_40](https://github.com/user-attachments/assets/43b155d5-b5f5-4420-a6c5-0d938d97fc87)

This change significantly improves usability for viewing wide images without sacrificing the "full height" experience.